### PR TITLE
Dao-less LockManager

### DIFF
--- a/src/LockManager.sol
+++ b/src/LockManager.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import {ILockManager, LockManagerSettings, UnlockMode, PluginMode} from "./interfaces/ILockManager.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {DaoAuthorizable} from "@aragon/osx-commons-contracts/src/permission/auth/DaoAuthorizable.sol";
 import {ILockToGovernBase} from "./interfaces/ILockToGovernBase.sol";
 import {ILockToApprove} from "./interfaces/ILockToApprove.sol";
 import {ILockToVote} from "./interfaces/ILockToVote.sol";
@@ -15,7 +14,7 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 /// @title LockManager
 /// @author Aragon X 2025
 /// @notice Helper contract acting as the vault for locked tokens used to vote on multiple plugins and proposals.
-contract LockManager is ILockManager, DaoAuthorizable {
+contract LockManager is ILockManager {
     using EnumerableSet for EnumerableSet.UintSet;
 
     /// @notice The current LockManager settings
@@ -66,13 +65,10 @@ contract LockManager is ILockManager, DaoAuthorizable {
     /// @notice Thrown when trying to define the address of the plugin after it already was
     error SetPluginAddressForbidden();
 
-    /// @param _dao The address of the DAO where permissions should be checked by this contract
     /// @param _settings The operation mode of the contract (plugin mode and unlock mode)
     /// @param _token The address of the token contract that users can lock
     /// @param _underlyingToken If applicable, the address of the contract from which `token` originates. This is relevant for LP tokens whose supply may experiment swift changes.
-    constructor(IDAO _dao, LockManagerSettings memory _settings, IERC20 _token, IERC20 _underlyingToken)
-        DaoAuthorizable(_dao)
-    {
+    constructor(LockManagerSettings memory _settings, IERC20 _token, IERC20 _underlyingToken) {
         settings.unlockMode = _settings.unlockMode;
         settings.pluginMode = _settings.pluginMode;
         token = _token;

--- a/src/setup/LockToApprovePluginSetup.sol
+++ b/src/setup/LockToApprovePluginSetup.sol
@@ -66,9 +66,8 @@ contract LockToApprovePluginSetup is PluginSetup {
 
     /// @notice The contract constructor deploying the implementation contracts to use.
     constructor() PluginSetup(address(new LockToApprovePlugin())) {
-        lockManagerImpl = new LockManager(
-            IDAO(address(0)), LockManagerSettings(UnlockMode(0), PluginMode(0)), IERC20(address(0)), IERC20(address(0))
-        );
+        lockManagerImpl =
+            new LockManager(LockManagerSettings(UnlockMode(0), PluginMode(0)), IERC20(address(0)), IERC20(address(0)));
     }
 
     /// @inheritdoc IPluginSetup
@@ -86,7 +85,6 @@ contract LockToApprovePluginSetup is PluginSetup {
         // Lock Manager
         helpers[0] = address(
             new LockManager(
-                IDAO(_dao),
                 LockManagerSettings(installationParams.unlockMode, PluginMode.Approval),
                 installationParams.token,
                 installationParams.underlyingToken

--- a/src/setup/LockToVotePluginSetup.sol
+++ b/src/setup/LockToVotePluginSetup.sol
@@ -66,9 +66,8 @@ contract LockToVotePluginSetup is PluginSetup {
 
     /// @notice The contract constructor deploying the implementation contracts to use.
     constructor() PluginSetup(address(new LockToVotePlugin())) {
-        lockManagerImpl = new LockManager(
-            IDAO(address(0)), LockManagerSettings(UnlockMode(0), PluginMode(0)), IERC20(address(0)), IERC20(address(0))
-        );
+        lockManagerImpl =
+            new LockManager(LockManagerSettings(UnlockMode(0), PluginMode(0)), IERC20(address(0)), IERC20(address(0)));
     }
 
     /// @inheritdoc IPluginSetup
@@ -86,7 +85,6 @@ contract LockToVotePluginSetup is PluginSetup {
         // Lock Manager
         helpers[0] = address(
             new LockManager(
-                IDAO(_dao),
                 LockManagerSettings(installationParams.unlockMode, PluginMode.Voting),
                 installationParams.token,
                 installationParams.underlyingToken

--- a/test/LockManager.t.sol
+++ b/test/LockManager.t.sol
@@ -62,15 +62,13 @@ contract LockManagerTest is TestBase {
         // It Should set the token address correctly
         // It Should set the underlying token address correctly
         // It Should initialize the plugin address to address(0)
-        IDAO testDao = IDAO(address(dao));
         IERC20 testToken = IERC20(address(new TestToken()));
         IERC20 testUnderlying = IERC20(address(new TestToken()));
         LockManagerSettings memory settings =
             LockManagerSettings({unlockMode: UnlockMode.Strict, pluginMode: PluginMode.Approval});
 
-        LockManager newLockManager = new LockManager(testDao, settings, testToken, testUnderlying);
+        LockManager newLockManager = new LockManager(settings, testToken, testUnderlying);
 
-        assertEq(address(newLockManager.dao()), address(testDao), "DAO address mismatch");
         (UnlockMode um, PluginMode pm) = newLockManager.settings();
         assertEq(uint8(um), uint8(UnlockMode.Strict), "Unlock mode mismatch");
         assertEq(uint8(pm), uint8(PluginMode.Approval), "Plugin mode mismatch");
@@ -82,16 +80,15 @@ contract LockManagerTest is TestBase {
     function test_WhenDeployingWithAZeroaddressForTheUnderlyingToken() external givenTheContractIsBeingDeployed {
         // It Should set the underlying token address to address(0)
         LockManager newLockManager = new LockManager(
-            dao, LockManagerSettings(UnlockMode.Strict, PluginMode.Approval), lockableToken, IERC20(address(0))
+            LockManagerSettings(UnlockMode.Strict, PluginMode.Approval), lockableToken, IERC20(address(0))
         );
 
         assertEq(address(newLockManager.underlyingToken()), address(lockableToken));
     }
 
     modifier givenThePluginAddressHasNotBeenSetYet() {
-        lockManager = new LockManager(
-            dao, LockManagerSettings(UnlockMode.Strict, PluginMode.Approval), lockableToken, underlyingToken
-        );
+        lockManager =
+            new LockManager(LockManagerSettings(UnlockMode.Strict, PluginMode.Approval), lockableToken, underlyingToken);
         _;
     }
 
@@ -133,9 +130,8 @@ contract LockManagerTest is TestBase {
     }
 
     modifier givenThePluginModeIsVoting() {
-        lockManager = new LockManager(
-            dao, LockManagerSettings(UnlockMode.Strict, PluginMode.Voting), lockableToken, underlyingToken
-        );
+        lockManager =
+            new LockManager(LockManagerSettings(UnlockMode.Strict, PluginMode.Voting), lockableToken, underlyingToken);
         _;
     }
 

--- a/test/LockToApprove.t.sol
+++ b/test/LockToApprove.t.sol
@@ -58,10 +58,7 @@ contract LockToApproveTest is TestBase {
         LOCK_TO_APPROVE_BASE = address(new LockToApprovePlugin());
         LOCK_MANAGER_BASE = address(
             new LockManager(
-                IDAO(address(0)),
-                LockManagerSettings(UnlockMode.Standard, PluginMode.Approval),
-                IERC20(address(0)),
-                IERC20(address(0))
+                LockManagerSettings(UnlockMode.Standard, PluginMode.Approval), IERC20(address(0)), IERC20(address(0))
             )
         );
 
@@ -137,9 +134,8 @@ contract LockToApproveTest is TestBase {
             IPlugin.TargetConfig({target: address(newDao), operation: IPlugin.Operation.Call});
         bytes memory pluginMetadata = "ipfs://1234";
 
-        newLockManager = new LockManager(
-            newDao, LockManagerSettings(UnlockMode.Standard, PluginMode.Approval), newToken, IERC20(address(0))
-        );
+        newLockManager =
+            new LockManager(LockManagerSettings(UnlockMode.Standard, PluginMode.Approval), newToken, IERC20(address(0)));
 
         newPlugin = LockToApprovePlugin(
             createProxyAndCall(

--- a/test/LockToVote.t.sol
+++ b/test/LockToVote.t.sol
@@ -107,7 +107,6 @@ contract LockToVoteTest is TestBase {
         ).withTokenHolder(carol, 10 ether).withTokenHolder(david, 15 ether).build();
 
         lockManager = new LockManager(
-            dao,
             LockManagerSettings({unlockMode: UnlockMode.Strict, pluginMode: PluginMode.Voting}),
             lockableToken,
             underlyingToken

--- a/test/builders/DaoBuilder.sol
+++ b/test/builders/DaoBuilder.sol
@@ -160,8 +160,7 @@ contract DaoBuilder is Test {
         {
             // Plugin and helper
 
-            lockManager =
-                new LockManager(dao, LockManagerSettings(unlockMode, pluginMode), lockableToken, underlyingToken);
+            lockManager = new LockManager(LockManagerSettings(unlockMode, pluginMode), lockableToken, underlyingToken);
 
             bytes memory pluginMetadata = "";
             IPlugin.TargetConfig memory targetConfig =


### PR DESCRIPTION
~~#9 should be addressed first~~

- The Lock Manager was `DaoAuthorizable` initially
- However, it ended up not using any permission from any DAO
- This PR removes the LockManager's dependency on a DAO that is not needed