### PR TITLE
Locking specific token amounts

### DIFF
--- a/src/LockManagerERC20.sol
+++ b/src/LockManagerERC20.sol
@@ -28,19 +28,17 @@ contract LockManagerERC20 is ILockManager, LockManagerBase {
     // Overrides
 
     /// @inheritdoc LockManagerBase
-    function _transfer(address _recipient, uint256 _amount) internal virtual override {
-        erc20Token.transfer(_recipient, _amount);
+    function _incomingTokenBalance() internal view virtual override returns (uint256) {
+        return erc20Token.allowance(msg.sender, address(this));
     }
 
     /// @inheritdoc LockManagerBase
-    function _lock() internal virtual override {
-        uint256 _allowance = erc20Token.allowance(msg.sender, address(this));
-        if (_allowance == 0) {
-            revert NoBalance();
-        }
+    function _doLockTransfer(uint256 _amount) internal virtual override {
+        erc20Token.transferFrom(msg.sender, address(this), _amount);
+    }
 
-        erc20Token.transferFrom(msg.sender, address(this), _allowance);
-        lockedBalances[msg.sender] += _allowance;
-        emit BalanceLocked(msg.sender, _allowance);
+    /// @inheritdoc LockManagerBase
+    function _doUnlockTransfer(address _recipient, uint256 _amount) internal virtual override {
+        erc20Token.transfer(_recipient, _amount);
     }
 }

--- a/src/interfaces/ILockManager.sol
+++ b/src/interfaces/ILockManager.sol
@@ -39,19 +39,35 @@ interface ILockManager {
     /// @notice Locks the balance currently allowed by msg.sender on this contract
     function lock() external;
 
+    /// @notice Locks the given amount from msg.sender on this contract
+    /// @param amount How many tokens the contract should lock
+    function lock(uint256 amount) external;
+
     /// @notice Locks the balance currently allowed by msg.sender on this contract and registers an approval on the target plugin
     /// @param proposalId The ID of the proposal where the approval will be registered
     function lockAndApprove(uint256 proposalId) external;
 
+    /// @notice Locks the given amount from msg.sender on this contract and registers an approval on the target plugin
+    /// @param proposalId The ID of the proposal where the approval will be registered
+    /// @param amount How many tokens the contract should lock and use for voting
+    function lockAndApprove(uint256 proposalId, uint256 amount) external;
+
     /// @notice Locks the balance currently allowed by msg.sender on this contract and registers the given vote on the target plugin
     /// @param proposalId The ID of the proposal where the vote will be registered
+    /// @param vote The vote to cast (Yes, No, Abstain)
     function lockAndVote(uint256 proposalId, IMajorityVoting.VoteOption vote) external;
+
+    /// @notice Locks the given amount from msg.sender on this contract and registers the given vote on the target plugin
+    /// @param proposalId The ID of the proposal where the vote will be registered
+    /// @param vote The vote to cast (Yes, No, Abstain)
+    /// @param amount How many tokens the contract should lock and use for voting
+    function lockAndVote(uint256 proposalId, IMajorityVoting.VoteOption vote, uint256 amount) external;
 
     /// @notice Uses the locked balance to place an approval on the given proposal for the registered plugin
     /// @param proposalId The ID of the proposal where the approval will be registered
     function approve(uint256 proposalId) external;
 
-    /// @notice Uses the locked balance to place the given vote on the given proposal for the registered plugin
+    /// @notice Uses the locked balance to vote on the given proposal for the registered plugin
     /// @param proposalId The ID of the proposal where the vote will be registered
     function vote(uint256 proposalId, IMajorityVoting.VoteOption vote) external;
 
@@ -70,7 +86,7 @@ interface ILockManager {
         view
         returns (bool);
 
-    /// @notice If the mode allows it, releases all active locks placed on active proposals and transfers msg.sender's locked balance back. Depending on the current mode, it withdraws only if no locks are being used in active proposals.
+    /// @notice If the governance plugin allows it, releases all active locks placed on active proposals and transfers msg.sender's locked balance back. Depending on the current mode, it withdraws only if no locks are being used in active proposals.
     function unlock() external;
 
     /// @notice Called by the lock to vote plugin whenever a proposal is created. It instructs the manager to start tracking the given proposal.


### PR DESCRIPTION

Context:
- `lock()` `lockAndApprove()` and `lockAndVote()` currently use all the available (approved) ERC20 balance or the ETH `value` given to the current transaction
- The UI may want to specify the amount to actually lock, regardless of the current allowance

Changes:
- Adding a twin implementation of `lock()` `lockAndApprove()` and `lockAndVote()` with a new `amount` parameter