### PR TITLE
Checking the locked balance in the MinVotingPowerCondition

### DIFF
--- a/src/conditions/MinVotingPowerCondition.sol
+++ b/src/conditions/MinVotingPowerCondition.sol
@@ -16,14 +16,24 @@ contract MinVotingPowerCondition is PermissionCondition {
     /// @notice The address of the `ILockToGovernBase` plugin used to fetch the settings from.
     ILockToGovernBase public immutable plugin;
 
-    /// @notice The `IERC20` token interface used to check token balance.
+    /// @notice The `IERC20` token used to check token balance.
     IERC20 public immutable token;
+
+    /// @notice The (optional) underlying token from which `token` originates.
+    IERC20 public immutable underlyingToken;
 
     /// @notice Initializes the contract with the `ILockToGovernBase` plugin address and caches the associated token.
     /// @param _plugin The address of the `ILockToGovernBase` plugin.
     constructor(ILockToGovernBase _plugin) {
         plugin = _plugin;
-        token = plugin.token();
+        token = _plugin.token();
+
+        /// Checking the underlying token as well
+        IERC20 _underlyingToken = _plugin.underlyingToken();
+        /// @dev If the address is the same as the voting token, it means that there is no underlying token.
+        if (address(_underlyingToken) != address(token)) {
+            underlyingToken = _underlyingToken;
+        }
     }
 
     /// @inheritdoc IPermissionCondition
@@ -37,12 +47,13 @@ contract MinVotingPowerCondition is PermissionCondition {
     {
         (_where, _data, _permissionId);
 
-        uint256 minProposerVotingPower_ = plugin.minProposerVotingPower();
+        uint256 _minProposerVotingPower = plugin.minProposerVotingPower();
 
-        if (token.balanceOf(_who) < minProposerVotingPower_) {
-            return false;
+        uint256 _callerBalance = token.balanceOf(_who);
+        if (address(underlyingToken) != address(0)) {
+            _callerBalance += underlyingToken.balanceOf(_who);
         }
 
-        return true;
+        return _callerBalance >= _minProposerVotingPower;
     }
 }


### PR DESCRIPTION
Context:
- The MinVotingPower condition checks the current token balance to allow creating proposals
- However, locked tokens are not taken into account

Changes:
- Make the condition check both balances