### PR TITLE
Cleaning up unused functions and renaming overriddable state getters

### DIFF
--- a/src/LockToApprovePlugin.sol
+++ b/src/LockToApprovePlugin.sol
@@ -271,7 +271,7 @@ contract LockToApprovePlugin is
     function canApprove(uint256 _proposalId, address _voter) external view returns (bool) {
         Proposal storage proposal_ = proposals[_proposalId];
 
-        return _canApprove(proposal_, _voter, lockManager.lockedBalances(_voter));
+        return _canApprove(proposal_, _voter, lockManager.getLockedBalance(_voter));
     }
 
     /// @inheritdoc ILockToApprove

--- a/src/LockToVotePlugin.sol
+++ b/src/LockToVotePlugin.sol
@@ -138,7 +138,7 @@ contract LockToVotePlugin is ILockToVote, MajorityVotingBase, LockToGovernBase {
         }
 
         Proposal storage proposal_ = proposals[_proposalId];
-        return _canVote(proposal_, _voter, _voteOption, lockManager.lockedBalances(_voter));
+        return _canVote(proposal_, _voter, _voteOption, lockManager.getLockedBalance(_voter));
     }
 
     /// @inheritdoc ILockToVote

--- a/src/base/LockToGovernBase.sol
+++ b/src/base/LockToGovernBase.sol
@@ -43,7 +43,7 @@ abstract contract LockToGovernBase is ILockToGovernBase, IMembership, ERC165Upgr
 
     /// @inheritdoc IMembership
     function isMember(address _account) external view returns (bool) {
-        if (lockManager.lockedBalances(_account) > 0) return true;
+        if (lockManager.getLockedBalance(_account) > 0) return true;
 
         IERC20 _token = token();
         if (address(_token) != address(0)) {

--- a/src/conditions/MinVotingPowerCondition.sol
+++ b/src/conditions/MinVotingPowerCondition.sol
@@ -42,7 +42,7 @@ contract MinVotingPowerCondition is PermissionCondition {
     {
         (_where, _data, _permissionId);
 
-        uint256 _currentBalance = token.balanceOf(_who) + lockManager.lockedBalances(_who);
+        uint256 _currentBalance = token.balanceOf(_who) + lockManager.getLockedBalance(_who);
         uint256 _minProposerVotingPower = plugin.minProposerVotingPower();
 
         return _currentBalance >= _minProposerVotingPower;

--- a/src/interfaces/ILockManager.sol
+++ b/src/interfaces/ILockManager.sol
@@ -34,7 +34,7 @@ interface ILockManager {
     function token() external view returns (address);
 
     /// @notice Returns the currently locked balance that the given account has on the contract.
-    function lockedBalances(address account) external view returns (uint256);
+    function getLockedBalance(address account) external view returns (uint256);
 
     /// @notice Locks the balance currently allowed by msg.sender on this contract
     function lock() external;

--- a/test/LockToVote.t.sol
+++ b/test/LockToVote.t.sol
@@ -561,7 +561,7 @@ contract LockToVoteTest is TestBase {
 
         _lock(alice, 1 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
 
         vm.expectEmit(true, true, true, true);
         emit IMajorityVoting.VoteCast(proposalId, alice, IMajorityVoting.VoteOption.Yes, aliceBalance);
@@ -616,7 +616,7 @@ contract LockToVoteTest is TestBase {
 
         _lock(alice, 1 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
         vm.prank(alice);
         lockManager.vote(proposalId, IMajorityVoting.VoteOption.Yes);
 
@@ -645,7 +645,7 @@ contract LockToVoteTest is TestBase {
 
         _vote(alice, IMajorityVoting.VoteOption.Yes, 0.5 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
 
         _lock(alice, 0.5 ether);
         // It should emit an event
@@ -680,7 +680,7 @@ contract LockToVoteTest is TestBase {
 
         _vote(alice, IMajorityVoting.VoteOption.Yes, 0.5 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
 
         // It should revert
         vm.expectRevert(abi.encodeWithSelector(VoteCastForbidden.selector, proposalId, alice));
@@ -705,7 +705,7 @@ contract LockToVoteTest is TestBase {
 
         _vote(alice, IMajorityVoting.VoteOption.Yes, 0.5 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
         _lock(alice, 0.5 ether);
 
         // It should revert
@@ -742,7 +742,7 @@ contract LockToVoteTest is TestBase {
 
         _lock(alice, 1 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
 
         // It should emit an event
         vm.expectEmit(true, true, true, true);
@@ -798,7 +798,7 @@ contract LockToVoteTest is TestBase {
 
         _lock(alice, 1 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
         vm.prank(alice);
         lockManager.vote(proposalId, IMajorityVoting.VoteOption.Yes);
 
@@ -827,7 +827,7 @@ contract LockToVoteTest is TestBase {
 
         _vote(alice, IMajorityVoting.VoteOption.Yes, 0.5 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
 
         _lock(alice, 0.5 ether);
         // It should emit an event
@@ -862,7 +862,7 @@ contract LockToVoteTest is TestBase {
 
         _vote(alice, IMajorityVoting.VoteOption.Yes, 0.5 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
 
         (,,, MajorityVotingBase.Tally memory tally,,,) = ltvPlugin.getProposal(proposalId);
         assertEq(tally.yes, aliceBalance);
@@ -909,7 +909,7 @@ contract LockToVoteTest is TestBase {
 
         _vote(alice, IMajorityVoting.VoteOption.Yes, 0.5 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
 
         (,,, MajorityVotingBase.Tally memory tally,,,) = ltvPlugin.getProposal(proposalId);
         assertEq(tally.yes, aliceBalance);
@@ -971,7 +971,7 @@ contract LockToVoteTest is TestBase {
 
         _lock(alice, 1 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
 
         // It should emit an event
         vm.expectEmit(true, true, true, true);
@@ -1027,7 +1027,7 @@ contract LockToVoteTest is TestBase {
 
         _lock(alice, 1 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
         vm.prank(alice);
         lockManager.vote(proposalId, IMajorityVoting.VoteOption.Yes);
 
@@ -1056,7 +1056,7 @@ contract LockToVoteTest is TestBase {
 
         _vote(alice, IMajorityVoting.VoteOption.Yes, 0.5 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
 
         _lock(alice, 0.5 ether);
         // It should emit an event
@@ -1091,7 +1091,7 @@ contract LockToVoteTest is TestBase {
 
         _vote(alice, IMajorityVoting.VoteOption.Yes, 0.5 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
         _lock(alice, 0.5 ether);
 
         // It should revert
@@ -1117,7 +1117,7 @@ contract LockToVoteTest is TestBase {
 
         _vote(alice, IMajorityVoting.VoteOption.Yes, 0.5 ether);
 
-        uint256 aliceBalance = lockManager.lockedBalances(alice);
+        uint256 aliceBalance = lockManager.getLockedBalance(alice);
         _lock(alice, 0.5 ether);
 
         // It should revert


### PR DESCRIPTION
- Removing the unused internal function `_hasActiveLocks`, which is now redundant
- Renaming `lockedBalances` into `getLockedBalance()` so that it can be overridden by future variants