### PR TITLE
SB30 + SB39:  Proposal creation condition

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -72,15 +72,19 @@ LockManagerERC20Test
 │       ├── Given The user has votes on open proposals
 │       │   ├── Given Standard voting mode
 │       │   │   └── When Calling unlock 3
-│       │   │       ├── It Should call clearVote() on the plugin for each active proposal
-│       │   │       ├── It Should transfer the locked balance back to the user
-│       │   │       ├── It Should set the user's lockedBalances to 0
-│       │   │       └── It Should emit a BalanceUnlocked event
+│       │   │       └── It Should revert
 │       │   └── Given Vote replacement mode
 │       │       └── When Calling unlock 4
-│       │           └── It Should revert with ProposalCreatedStillOpen
+│       │           ├── It Should call clearVote() on the plugin for each active proposal
+│       │           ├── It Should transfer the locked balance back to the user
+│       │           ├── It Should set the user's lockedBalances to 0
+│       │           └── It Should emit a BalanceUnlocked event
+│       ├── Given The user created active proposals
+│       │   └── When Calling unlock 5
+│       │       ├── It Should revert with ProposalCreatedStillOpen (standard voting)
+│       │       └── It Should revert with ProposalCreatedStillOpen (vote replacement)
 │       └── Given The user only has votes on proposals that are now closed or ended // The contract should garbage-collect the closed proposal during the check
-│           └── When Calling unlock 5
+│           └── When Calling unlock 6
 │               ├── It Should not attempt to clear votes for the closed proposal
 │               ├── It Should remove the closed proposal from knownProposalIds
 │               └── It Should succeed and transfer the locked balance back to the user

--- a/TESTS.md
+++ b/TESTS.md
@@ -81,8 +81,8 @@ LockManagerERC20Test
 │       │           └── It Should emit a BalanceUnlocked event
 │       ├── Given The user created active proposals
 │       │   └── When Calling unlock 5
-│       │       ├── It Should revert with ProposalCreatedStillOpen (standard voting)
-│       │       └── It Should revert with ProposalCreatedStillOpen (vote replacement)
+│       │       ├── It Should revert with ProposalCreatedStillActive (standard voting)
+│       │       └── It Should revert with ProposalCreatedStillActive (vote replacement)
 │       └── Given The user only has votes on proposals that are now closed or ended // The contract should garbage-collect the closed proposal during the check
 │           └── When Calling unlock 6
 │               ├── It Should not attempt to clear votes for the closed proposal
@@ -415,4 +415,3 @@ MinVotingPowerConditionTest
     └── Given the sender created many proposals
         └── It the voting power required should be proportional to the amount of proposals created
 ```
-

--- a/src/LockToVotePlugin.sol
+++ b/src/LockToVotePlugin.sol
@@ -128,7 +128,7 @@ contract LockToVotePlugin is ILockToVote, MajorityVotingBase, LockToGovernBase {
 
         emit ProposalCreated(proposalId, _msgSender(), _startDate, _endDate, _metadata, _actions, _allowFailureMap);
 
-        lockManager.proposalCreated(proposalId);
+        lockManager.proposalCreated(proposalId, _msgSender());
     }
 
     /// @inheritdoc ILockToVote

--- a/src/base/LockManagerBase.sol
+++ b/src/base/LockManagerBase.sol
@@ -269,13 +269,13 @@ abstract contract LockManagerBase is ILockManager {
 
             // The proposal is open
 
+            if (knownProposalIdCreators[_proposalId] == msg.sender) {
+                revert ProposalCreatedStillOpen(_proposalId);
+            }
+
             if (plugin.usedVotingPower(_proposalId, msg.sender) > 0) {
                 /// @dev The plugin should revert if the voting mode doesn't allow it
                 ILockToVote(address(plugin)).clearVote(_proposalId, msg.sender);
-            }
-
-            if (knownProposalIdCreators[_proposalId] == msg.sender) {
-                revert ProposalCreatedStillOpen(_proposalId);
             }
 
             unchecked {

--- a/src/base/LockManagerBase.sol
+++ b/src/base/LockManagerBase.sol
@@ -63,7 +63,7 @@ abstract contract LockManagerBase is ILockManager {
 
     /// @notice Thrown when attempting to unlock with a created proposal that is still active
     /// @param proposalId The ID the active proposal
-    error ProposalCreatedStillOpen(uint256 proposalId);
+    error ProposalCreatedStillActive(uint256 proposalId);
 
     /// @param _settings The operation mode of the contract (plugin mode)
     constructor(LockManagerSettings memory _settings) {
@@ -270,7 +270,7 @@ abstract contract LockManagerBase is ILockManager {
             // The proposal is open
 
             if (knownProposalIdCreators[_proposalId] == msg.sender) {
-                revert ProposalCreatedStillOpen(_proposalId);
+                revert ProposalCreatedStillActive(_proposalId);
             }
 
             if (plugin.usedVotingPower(_proposalId, msg.sender) > 0) {

--- a/src/base/LockManagerBase.sol
+++ b/src/base/LockManagerBase.sol
@@ -28,7 +28,7 @@ abstract contract LockManagerBase is ILockManager {
     EnumerableSet.UintSet internal knownProposalIds;
 
     /// @notice Keeps track of who created each known proposalId
-    mapping(uint256 => address) internal knownProposalIdCreators;
+    mapping(uint256 => address) public knownProposalIdCreators;
 
     /// @notice The address that can define the plugin address, once, after the deployment
     address immutable pluginSetter;

--- a/src/base/LockManagerBase.sol
+++ b/src/base/LockManagerBase.sol
@@ -89,7 +89,7 @@ abstract contract LockManagerBase is ILockManager {
             uint256 _proposalId = knownProposalIds.at(_i);
             if (knownProposalIdCreators[_proposalId] != _creator) {
                 continue;
-            } else if (!plugin.isProposalOpen(_proposalId)) {
+            } else if (plugin.isProposalEnded(_proposalId)) {
                 continue;
             }
             _result++;

--- a/src/conditions/MinVotingPowerCondition.sol
+++ b/src/conditions/MinVotingPowerCondition.sol
@@ -42,9 +42,14 @@ contract MinVotingPowerCondition is PermissionCondition {
         (_where, _data, _permissionId);
 
         uint256 _currentVotingPower = lockManager.getLockedBalance(_who);
+
+        return _currentVotingPower >= getRequiredLockAmount(_who);
+    }
+
+    function getRequiredLockAmount(address _who) public view virtual returns (uint256) {
         uint256 _minProposerVotingPower = plugin.minProposerVotingPower();
         uint256 _multiplier = lockManager.activeProposalsCreatedBy(_who) + 1;
 
-        return _currentVotingPower >= (_minProposerVotingPower * _multiplier);
+        return _minProposerVotingPower * _multiplier;
     }
 }

--- a/src/conditions/MinVotingPowerCondition.sol
+++ b/src/conditions/MinVotingPowerCondition.sol
@@ -41,9 +41,10 @@ contract MinVotingPowerCondition is PermissionCondition {
     {
         (_where, _data, _permissionId);
 
-        uint256 _currentBalance = token.balanceOf(_who) + lockManager.getLockedBalance(_who);
+        uint256 _currentVotingPower = lockManager.getLockedBalance(_who);
         uint256 _minProposerVotingPower = plugin.minProposerVotingPower();
+        uint256 _multiplier = lockManager.activeProposalsCreatedBy(_who) + 1;
 
-        return _currentBalance >= _minProposerVotingPower;
+        return _currentVotingPower >= (_minProposerVotingPower * _multiplier);
     }
 }

--- a/src/interfaces/ILockManager.sol
+++ b/src/interfaces/ILockManager.sol
@@ -35,6 +35,10 @@ interface ILockManager {
     /// @notice Returns the currently locked balance that the given account has on the contract.
     function getLockedBalance(address account) external view returns (uint256);
 
+    /// @notice Returns how many active proposalID's were created by the given address
+    /// @param _creator The address to use for filtering
+    function activeProposalsCreatedBy(address _creator) external view returns (uint256 _result);
+
     /// @notice Locks the balance currently allowed by msg.sender on this contract
     /// NOTE: Tokens locked and not allocated into a proposal are treated in the same way as the rest.
     /// They can only be unlocked when all active proposals with votes have ended.
@@ -81,7 +85,8 @@ interface ILockManager {
 
     /// @notice Called by the lock to vote plugin whenever a proposal is created. It instructs the manager to start tracking the given proposal.
     /// @param proposalId The ID of the proposal that msg.sender is reporting as created.
-    function proposalCreated(uint256 proposalId) external;
+    /// @param creator The address that .
+    function proposalCreated(uint256 proposalId, address creator) external;
 
     /// @notice Called by the lock to vote plugin whenever a proposal is executed (or ended). It instructs the manager to remove the proposal from the list of active proposal locks.
     /// @param proposalId The ID of the proposal that msg.sender is reporting as done.

--- a/src/interfaces/ILockManager.sol
+++ b/src/interfaces/ILockManager.sol
@@ -85,7 +85,7 @@ interface ILockManager {
 
     /// @notice Called by the lock to vote plugin whenever a proposal is created. It instructs the manager to start tracking the given proposal.
     /// @param proposalId The ID of the proposal that msg.sender is reporting as created.
-    /// @param creator The address that .
+    /// @param creator The address creating the proposal.
     function proposalCreated(uint256 proposalId, address creator) external;
 
     /// @notice Called by the lock to vote plugin whenever a proposal is executed (or ended). It instructs the manager to remove the proposal from the list of active proposal locks.

--- a/test/LockManagerERC20.t.sol
+++ b/test/LockManagerERC20.t.sol
@@ -245,7 +245,7 @@ contract LockManagerERC20Test is TestBase {
         Action[] memory _actions = new Action[](0);
         proposalId = ltvPlugin.createProposal(bytes(""), _actions, 0, 0, bytes(""));
         vm.prank(address(ltvPlugin));
-        lockManager.proposalCreated(proposalId);
+        lockManager.proposalCreated(proposalId, address(this));
         _;
     }
 
@@ -383,7 +383,7 @@ contract LockManagerERC20Test is TestBase {
         proposalId = ltvPlugin.createProposal(bytes(""), _actions, 0, 0, bytes(""));
 
         vm.prank(address(ltvPlugin));
-        lockManager.proposalCreated(proposalId);
+        lockManager.proposalCreated(proposalId, address(this));
 
         vm.prank(alice);
         lockableToken.approve(address(lockManager), 0.5 ether);
@@ -463,7 +463,7 @@ contract LockManagerERC20Test is TestBase {
         Action[] memory _actions = new Action[](0);
         proposalId = ltvPlugin.createProposal(bytes(""), _actions, 0, 0, bytes(""));
         vm.prank(address(ltvPlugin));
-        lockManager.proposalCreated(proposalId);
+        lockManager.proposalCreated(proposalId, address(this));
 
         vm.prank(alice);
         lockableToken.approve(address(lockManager), 1 ether);
@@ -497,7 +497,7 @@ contract LockManagerERC20Test is TestBase {
         Action[] memory _actions = new Action[](0);
         proposalId = ltvPlugin.createProposal(bytes(""), _actions, 0, 0, bytes(""));
         vm.prank(address(ltvPlugin));
-        lockManager.proposalCreated(proposalId);
+        lockManager.proposalCreated(proposalId, address(this));
 
         vm.prank(alice);
         lockableToken.approve(address(lockManager), 1 ether);
@@ -548,7 +548,11 @@ contract LockManagerERC20Test is TestBase {
         // It Should revert with InvalidPluginAddress
         vm.prank(bob);
         vm.expectRevert(InvalidPluginAddress.selector);
-        lockManager.proposalCreated(1);
+        lockManager.proposalCreated(1, address(this));
+
+        vm.prank(bob);
+        vm.expectRevert(InvalidPluginAddress.selector);
+        lockManager.proposalCreated(1, alice);
     }
 
     function test_WhenCallingProposalEnded() external givenThePluginHasBeenSet givenTheCallerIsNotTheRegisteredPlugin {
@@ -569,13 +573,13 @@ contract LockManagerERC20Test is TestBase {
     {
         // It Should add the proposal ID to knownProposalIds
         vm.prank(address(lockManager.plugin()));
-        lockManager.proposalCreated(123);
+        lockManager.proposalCreated(123, address(this));
         assertEq(lockManager.knownProposalIdAt(0), 123);
     }
 
     modifier givenAProposalIDIsAlreadyKnown() {
         vm.prank(address(lockManager.plugin()));
-        lockManager.proposalCreated(123);
+        lockManager.proposalCreated(123, address(this));
         _;
     }
 
@@ -588,7 +592,7 @@ contract LockManagerERC20Test is TestBase {
         // It Should not change the set of known proposals
         uint256 initialLength = lockManager.knownProposalIdsLength();
         vm.prank(address(lockManager.plugin()));
-        lockManager.proposalCreated(123);
+        lockManager.proposalCreated(123, address(this));
         assertEq(lockManager.knownProposalIdsLength(), initialLength);
     }
 
@@ -646,9 +650,9 @@ contract LockManagerERC20Test is TestBase {
 
     modifier givenTheContractHasSeveralKnownProposalIDs() {
         vm.startPrank(address(ltvPlugin));
-        lockManager.proposalCreated(101);
-        lockManager.proposalCreated(102);
-        lockManager.proposalCreated(103);
+        lockManager.proposalCreated(101, address(this));
+        lockManager.proposalCreated(102, address(this));
+        lockManager.proposalCreated(103, address(this));
         vm.stopPrank();
 
         _;

--- a/test/LockManagerERC20.t.sol
+++ b/test/LockManagerERC20.t.sol
@@ -35,6 +35,7 @@ contract LockManagerERC20Test is TestBase {
     error SetPluginAddressForbidden();
     error InvalidPluginMode();
     error InvalidPluginAddress();
+    error VoteRemovalForbidden(uint256 proposalId, address voter);
 
     function setUp() public {
         vm.warp(1 days);
@@ -523,15 +524,18 @@ contract LockManagerERC20Test is TestBase {
         _;
     }
 
-    function test_WhenCallingUnlock3()
+    function test_RevertWhen_CallingUnlock3()
         external
         givenAUserWantsToUnlockTokens
         givenTheUserHasALockedBalance2
-        givenStandardVotingMode
         givenTheUserHasVotesOnOpenProposals
+        givenStandardVotingMode
     {
         // It Should revert
-        vm.skip(true);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(VoteRemovalForbidden.selector, proposalId, alice));
+        lockManager.unlock();
     }
 
     function test_WhenCallingUnlock4()
@@ -598,6 +602,21 @@ contract LockManagerERC20Test is TestBase {
         assertEq(lockableToken.balanceOf(alice), initialBalance + lockedAmount);
         vm.expectRevert();
         lockManager.knownProposalIdAt(0);
+    }
+
+    modifier givenTheUserCreatedActiveProposals() {
+        _;
+    }
+
+    function test_WhenCallingUnlock6()
+        external
+        givenAUserWantsToUnlockTokens
+        givenTheUserHasALockedBalance2
+        givenTheUserCreatedActiveProposals
+    {
+        // It Should revert with ProposalCreatedStillOpen (standard voting)
+        // It Should revert with ProposalCreatedStillOpen (vote replacement)
+        vm.skip(true);
     }
 
     modifier givenThePluginHasBeenSet() {

--- a/test/LockManagerERC20.t.sol
+++ b/test/LockManagerERC20.t.sol
@@ -36,7 +36,7 @@ contract LockManagerERC20Test is TestBase {
     error InvalidPluginMode();
     error InvalidPluginAddress();
     error VoteRemovalForbidden(uint256 proposalId, address voter);
-    error ProposalCreatedStillOpen(uint256 proposalId);
+    error ProposalCreatedStillActive(uint256 proposalId);
 
     function setUp() public {
         vm.warp(1 days);
@@ -618,7 +618,7 @@ contract LockManagerERC20Test is TestBase {
         vm.startPrank(alice);
         Action[] memory _actions = new Action[](0);
 
-        // It Should revert with ProposalCreatedStillOpen (standard voting)
+        // It Should revert with ProposalCreatedStillActive (standard voting)
 
         (dao, ltvPlugin, lockManager, lockableToken) =
             builder.withStandardVoting().withTokenHolder(alice, 1 ether).withProposer(alice).build();
@@ -627,10 +627,10 @@ contract LockManagerERC20Test is TestBase {
         lockManager.lock();
         proposalId = ltvPlugin.createProposal(bytes(""), _actions, 0, 0, bytes(""));
 
-        vm.expectRevert(abi.encodeWithSelector(ProposalCreatedStillOpen.selector, proposalId));
+        vm.expectRevert(abi.encodeWithSelector(ProposalCreatedStillActive.selector, proposalId));
         lockManager.unlock();
 
-        // It Should revert with ProposalCreatedStillOpen (vote replacement)
+        // It Should revert with ProposalCreatedStillActive (vote replacement)
         (dao, ltvPlugin, lockManager, lockableToken) =
             builder.withVoteReplacement().withTokenHolder(alice, 1 ether).withProposer(alice).build();
 
@@ -638,7 +638,7 @@ contract LockManagerERC20Test is TestBase {
         lockManager.lock();
         proposalId = ltvPlugin.createProposal(bytes(""), _actions, 0, 0, bytes(""));
 
-        vm.expectRevert(abi.encodeWithSelector(ProposalCreatedStillOpen.selector, proposalId));
+        vm.expectRevert(abi.encodeWithSelector(ProposalCreatedStillActive.selector, proposalId));
         lockManager.unlock();
 
         vm.stopPrank();

--- a/test/LockManagerERC20.t.yaml
+++ b/test/LockManagerERC20.t.yaml
@@ -131,8 +131,8 @@ LockManagerERC20Test:
             and:
               - when: Calling unlock()
                 then:
-                  - it: Should revert with ProposalCreatedStillOpen (standard voting)
-                  - it: Should revert with ProposalCreatedStillOpen (vote replacement)
+                  - it: Should revert with ProposalCreatedStillActive (standard voting)
+                  - it: Should revert with ProposalCreatedStillActive (vote replacement)
           - given: The user only has votes on proposals that are now closed or ended
             comment: The contract should garbage-collect the closed proposal during the check
             and:

--- a/test/LockManagerERC20.t.yaml
+++ b/test/LockManagerERC20.t.yaml
@@ -148,15 +148,19 @@ LockManagerTest:
           - when: Calling proposalCreated() with a new proposal ID
             then:
               - it: Should add the proposal ID to knownProposalIds
+              - it: Should register the creator
+              - it: activeProposalsCreatedBy() should increase for the creator
           - given: A proposal ID is already known
             and:
               - when: Calling proposalCreated() with that same ID
                 then:
                   - it: Should not change the set of known proposals
+                  - it: activeProposalsCreatedBy() should remain the same for the creator
               - when: Calling proposalEnded() with that proposal ID
                 then:
                   - it: Should remove the proposal ID from knownProposalIds
                   - it: Should emit a ProposalEnded event
+                  - it: activeProposalsCreatedBy() should decrease for the creator
           - when: Calling proposalEnded() with a non-existent proposal ID
             then:
               - it: Should do nothing

--- a/test/LockManagerERC20.t.yaml
+++ b/test/LockManagerERC20.t.yaml
@@ -1,16 +1,12 @@
-LockManagerTest:
+LockManagerERC20Test:
   - given: The contract is being deployed
     and:
-      - when: Deploying with valid parameters and a non-zero underlying token
+      - when: Deploying with valid parameters
         then:
           - it: Should set the DAO address correctly
           - it: Should set the pluginMode correctly
           - it: Should set the token address correctly
-          - it: Should set the underlying token address correctly
           - it: Should initialize the plugin address to address(0)
-      - when: Deploying with a zero-address for the underlying token
-        then:
-          - it: Should set the underlying token address to address(0)
 
   - given: The plugin address has not been set yet
     and:
@@ -111,19 +107,26 @@ LockManagerTest:
               - it: Should revert with NoBalance
       - given: The user has a locked balance
         and:
-          - given: The user has no active votes on any open proposals
+          - given: No votes on open proposals and no active proposals created
             and:
               - when: Calling unlock()
                 then:
                   - it: Should succeed and transfer the locked balance back to the user
           - given: The user has votes on open proposals
             and:
-              - when: Calling unlock()
-                then:
-                  - it: Should call clearVote() on the plugin for each active proposal
-                  - it: Should transfer the locked balance back to the user
-                  - it: Should set the user's lockedBalances to 0
-                  - it: Should emit a BalanceUnlocked event
+              - given: Standard voting mode
+                and:
+                  - when: Calling unlock()
+                    then:
+                      - it: Should call clearVote() on the plugin for each active proposal
+                      - it: Should transfer the locked balance back to the user
+                      - it: Should set the user's lockedBalances to 0
+                      - it: Should emit a BalanceUnlocked event
+              - given: Vote replacement mode
+                and:
+                  - when: Calling unlock()
+                    then:
+                      - it: Should revert with ProposalCreatedStillOpen
           - given: The user only has votes on proposals that are now closed or ended
             comment: The contract should garbage-collect the closed proposal during the check
             and:

--- a/test/LockManagerERC20.t.yaml
+++ b/test/LockManagerERC20.t.yaml
@@ -118,15 +118,21 @@ LockManagerERC20Test:
                 and:
                   - when: Calling unlock()
                     then:
-                      - it: Should call clearVote() on the plugin for each active proposal
-                      - it: Should transfer the locked balance back to the user
-                      - it: Should set the user's lockedBalances to 0
-                      - it: Should emit a BalanceUnlocked event
+                      - it: Should revert
               - given: Vote replacement mode
                 and:
                   - when: Calling unlock()
                     then:
-                      - it: Should revert with ProposalCreatedStillOpen
+                      - it: Should call clearVote() on the plugin for each active proposal
+                      - it: Should transfer the locked balance back to the user
+                      - it: Should set the user's lockedBalances to 0
+                      - it: Should emit a BalanceUnlocked event
+          - given: The user created active proposals
+            and:
+              - when: Calling unlock()
+                then:
+                  - it: Should revert with ProposalCreatedStillOpen (standard voting)
+                  - it: Should revert with ProposalCreatedStillOpen (vote replacement)
           - given: The user only has votes on proposals that are now closed or ended
             comment: The contract should garbage-collect the closed proposal during the check
             and:

--- a/test/LockToVote.t.sol
+++ b/test/LockToVote.t.sol
@@ -281,6 +281,8 @@ contract LockToVoteTest is TestBase {
         (dao, ltvPlugin, lockManager, lockableToken) =
             new DaoBuilder().withTokenHolder(alice, 1 ether).withVotingPlugin().build();
 
+        _lock(alice, 1 ether);
+
         // Revoke unconditional permission for alice (default proposer in my setUp)
         dao.revoke(address(ltvPlugin), alice, ltvPlugin.CREATE_PROPOSAL_PERMISSION_ID());
 
@@ -296,7 +298,7 @@ contract LockToVoteTest is TestBase {
         dao.grantWithCondition(address(ltvPlugin), alice, ltvPlugin.CREATE_PROPOSAL_PERMISSION_ID(), condition);
 
         // It should revert when the creator has not enough balance
-        // Alice has 1 ether, min is 2 ether.
+        // Alice locked 1 ether, min is 2 ether.
         vm.expectRevert(
             abi.encodeWithSelector(
                 DaoUnauthorized.selector,
@@ -311,6 +313,8 @@ contract LockToVoteTest is TestBase {
 
         // It should succeed when the creator has enough balance
         TestToken(address(lockableToken)).mint(alice, 1 ether); // now alice has 2 ether
+        _lock(alice, 1 ether);
+
         vm.prank(alice);
         ltvPlugin.createProposal("ipfs://", actions, 0, 0, bytes(""));
     }

--- a/test/MinVotingPowerCondition.t.sol
+++ b/test/MinVotingPowerCondition.t.sol
@@ -154,6 +154,7 @@ contract MinVotingPowerConditionTest is TestBase {
             condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 15 ether, 0 locked
             "Should return false for user with less than min power"
         );
+        assertEq(condition.getRequiredLockAmount(david), 2 ether);
 
         token.approve(address(ltvPlugin.lockManager()), 1.9 ether);
         ltvPlugin.lockManager().lock();
@@ -161,6 +162,7 @@ contract MinVotingPowerConditionTest is TestBase {
             condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 13.1 ether, 1.9 locked
             "Should return false for user with less than min power"
         );
+        assertEq(condition.getRequiredLockAmount(david), 2 ether);
 
         token.approve(address(ltvPlugin.lockManager()), 0.1 ether);
         ltvPlugin.lockManager().lock();
@@ -168,6 +170,7 @@ contract MinVotingPowerConditionTest is TestBase {
             condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 13 ether, 2 locked
             "Should return true for user with >= min power"
         );
+        assertEq(condition.getRequiredLockAmount(david), 2 ether);
 
         ltvPlugin.createProposal(bytes(""), new Action[](0), 0, 0, bytes(""));
         vm.roll(block.number + 1);
@@ -180,6 +183,7 @@ contract MinVotingPowerConditionTest is TestBase {
             condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 11.1 ether, 3.9 locked
             "Should return false for user with less than min power"
         );
+        assertEq(condition.getRequiredLockAmount(david), 4 ether);
 
         token.approve(address(ltvPlugin.lockManager()), 0.1 ether);
         ltvPlugin.lockManager().lock();
@@ -187,6 +191,7 @@ contract MinVotingPowerConditionTest is TestBase {
             condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 11 ether, 4 locked
             "Should return true for user with >= min power"
         );
+        assertEq(condition.getRequiredLockAmount(david), 4 ether);
 
         ltvPlugin.createProposal(bytes(""), new Action[](0), 0, 0, bytes(""));
         vm.roll(block.number + 1);
@@ -199,6 +204,7 @@ contract MinVotingPowerConditionTest is TestBase {
             condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 9.1 ether, 5.9 locked
             "Should return false for user with less than min power"
         );
+        assertEq(condition.getRequiredLockAmount(david), 6 ether);
 
         token.approve(address(ltvPlugin.lockManager()), 0.1 ether);
         ltvPlugin.lockManager().lock();
@@ -206,5 +212,6 @@ contract MinVotingPowerConditionTest is TestBase {
             condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 9 ether, 6 locked
             "Should return true for user with >= min power"
         );
+        assertEq(condition.getRequiredLockAmount(david), 6 ether);
     }
 }

--- a/test/MinVotingPowerCondition.t.sol
+++ b/test/MinVotingPowerCondition.t.sol
@@ -5,6 +5,7 @@ import {TestBase} from "./lib/TestBase.sol";
 import {DaoBuilder} from "./builders/DaoBuilder.sol";
 import {DAO} from "@aragon/osx/src/core/dao/DAO.sol";
 import {LockToVotePlugin, MajorityVotingBase} from "../src/LockToVotePlugin.sol";
+import {Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {MinVotingPowerCondition} from "../src/conditions/MinVotingPowerCondition.sol";
 import {ILockToGovernBase} from "../src/interfaces/ILockToGovernBase.sol";
@@ -122,6 +123,88 @@ contract MinVotingPowerConditionTest is TestBase {
         assertTrue(
             condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 12 ether locked
             "Should return false for user with more than min power"
+        );
+    }
+
+    function test_GivenTheSenderCreatedManyProposals() external whenCallingIsGranted {
+        // Grant alice permission to update settings. Prank is active from setUp.
+        dao.grant(address(ltvPlugin), alice, ltvPlugin.UPDATE_SETTINGS_PERMISSION_ID());
+        dao.grant(address(ltvPlugin), david, ltvPlugin.CREATE_PROPOSAL_PERMISSION_ID());
+
+        // Update settings to require a minimum voting power
+        uint256 minPower = 2 ether;
+        MajorityVotingBase.VotingSettings memory newSettings = MajorityVotingBase.VotingSettings({
+            votingMode: MajorityVotingBase.VotingMode.VoteReplacement,
+            supportThresholdRatio: 500_000,
+            minParticipationRatio: ltvPlugin.minParticipationRatio(),
+            minApprovalRatio: 150_000,
+            proposalDuration: ltvPlugin.proposalDuration(),
+            minProposerVotingPower: minPower
+        });
+        ltvPlugin.updateVotingSettings(newSettings);
+
+        MinVotingPowerCondition condition = new MinVotingPowerCondition(ILockToGovernBase(address(ltvPlugin)));
+
+        // It the voting power required should be proportional to the amount of proposals created
+        vm.startPrank(david);
+
+        // 0 proposals
+
+        assertFalse(
+            condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 15 ether, 0 locked
+            "Should return false for user with less than min power"
+        );
+
+        token.approve(address(ltvPlugin.lockManager()), 1.9 ether);
+        ltvPlugin.lockManager().lock();
+        assertFalse(
+            condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 13.1 ether, 1.9 locked
+            "Should return false for user with less than min power"
+        );
+
+        token.approve(address(ltvPlugin.lockManager()), 0.1 ether);
+        ltvPlugin.lockManager().lock();
+        assertTrue(
+            condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 13 ether, 2 locked
+            "Should return true for user with >= min power"
+        );
+
+        ltvPlugin.createProposal(bytes(""), new Action[](0), 0, 0, bytes(""));
+        vm.roll(block.number + 1);
+
+        // 1 proposals
+
+        token.approve(address(ltvPlugin.lockManager()), 1.9 ether);
+        ltvPlugin.lockManager().lock();
+        assertFalse(
+            condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 11.1 ether, 3.9 locked
+            "Should return false for user with less than min power"
+        );
+
+        token.approve(address(ltvPlugin.lockManager()), 0.1 ether);
+        ltvPlugin.lockManager().lock();
+        assertTrue(
+            condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 11 ether, 4 locked
+            "Should return true for user with >= min power"
+        );
+
+        ltvPlugin.createProposal(bytes(""), new Action[](0), 0, 0, bytes(""));
+        vm.roll(block.number + 1);
+
+        // 2 proposals
+
+        token.approve(address(ltvPlugin.lockManager()), 1.9 ether);
+        ltvPlugin.lockManager().lock();
+        assertFalse(
+            condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 9.1 ether, 5.9 locked
+            "Should return false for user with less than min power"
+        );
+
+        token.approve(address(ltvPlugin.lockManager()), 0.1 ether);
+        ltvPlugin.lockManager().lock();
+        assertTrue(
+            condition.isGranted(address(0x0), david, bytes32(0x0), ""), // David has 9 ether, 6 locked
+            "Should return true for user with >= min power"
         );
     }
 }

--- a/test/MinVotingPowerCondition.t.yaml
+++ b/test/MinVotingPowerCondition.t.yaml
@@ -12,3 +12,6 @@ MinVotingPowerConditionTest:
         then:
           - it: should return true when 'who' holds the minimum voting power
           - it: should return false when 'who' holds less than the minimum voting power
+      - given: the sender created many proposals
+        then:
+          - it: the voting power required should be proportional to the amount of proposals created


### PR DESCRIPTION
- Ensure that only live tokens are accounted in MinVotingPowerCondition `isGranted()`
- Preventing flash loans to create proposals
  - Requiring `minProposerVotingPower * N` to create N proposals
  - Requiring 0 active created proposals to unlock