### PR TITLE
SB4: Locking as much as balance

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -28,10 +28,15 @@ LockManagerTest
 │   ├── When The user has not approved the LockManager to spend any tokens // Allowance is 0
 │   │   └── When Calling lock
 │   │       └── It Should revert with NoBalance
-│   └── When The user has approved the LockManager to spend tokens // Allowance is > 0
-│       └── When Calling lock 2
-│           ├── It Should transfer the full allowance amount from the user
-│           ├── It Should increase the user's lockedBalances by the allowance amount
+│   ├── When The user has approved the LockManager to spend tokens // Allowance is > 0
+│   │   └── When Calling lock 2
+│   │       ├── It Should transfer the full allowance amount from the user
+│   │       ├── It Should increase the user's lockedBalances by the allowance amount
+│   │       └── It Should emit a BalanceLocked event with the correct user and amount
+│   └── When The user has approved the LockManager to spend more than the balance // Allowance is ∞
+│       └── When Calling lock 3
+│           ├── It Should transfer the full balance from the user
+│           ├── It Should increase the user's lockedBalances by the balance
 │           └── It Should emit a BalanceLocked event with the correct user and amount
 ├── Given pluginMode is Voting
 │   └── Given A plugin is set and a proposal is active

--- a/src/LockManagerERC20.sol
+++ b/src/LockManagerERC20.sol
@@ -29,7 +29,9 @@ contract LockManagerERC20 is ILockManager, LockManagerBase {
 
     /// @inheritdoc LockManagerBase
     function _incomingTokenBalance() internal view virtual override returns (uint256) {
-        return erc20Token.allowance(msg.sender, address(this));
+        uint256 allowance = erc20Token.allowance(msg.sender, address(this));
+        uint256 balance = erc20Token.balanceOf(msg.sender);
+        return (allowance >= balance) ? balance : allowance;
     }
 
     /// @inheritdoc LockManagerBase

--- a/test/LockManagerERC20.t.sol
+++ b/test/LockManagerERC20.t.sol
@@ -142,6 +142,41 @@ contract LockManagerERC20Test is TestBase {
         assertEq(lockableToken.balanceOf(bob), initialBobBalance - allowance, "User balance incorrect");
     }
 
+    modifier whenTheUserHasApprovedTheLockManagerToSpendMoreThanTheBalance() {
+        TestToken(address(lockableToken)).mint(bob, 1 ether);
+
+        vm.prank(bob);
+        lockableToken.approve(address(lockManager), 1000000000 ether);
+
+        _;
+    }
+
+    function test_WhenCallingLock3()
+        external
+        givenAUserWantsToLockTokens
+        whenTheUserHasApprovedTheLockManagerToSpendMoreThanTheBalance
+    {
+        // It Should transfer the full balance from the user
+        // It Should increase the user's lockedBalances by the balance
+        // It Should emit a BalanceLocked event with the correct user and amount
+
+        uint256 allowance = lockableToken.allowance(bob, address(lockManager));
+        uint256 initialBobBalance = lockableToken.balanceOf(bob);
+
+        vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit BalanceLocked(bob, initialBobBalance);
+        lockManager.lock();
+
+        assertEq(lockManager.getLockedBalance(bob), initialBobBalance, "Incorrect locked balance");
+        assertEq(lockableToken.balanceOf(bob), 0, "Incorrect user balance");
+        assertEq(
+            lockableToken.allowance(bob, address(lockManager)),
+            allowance - initialBobBalance,
+            "Incorrect allowance left"
+        );
+    }
+
     modifier givenVotingPluginIsActive() {
         (dao, ltvPlugin, lockManager, lockableToken) =
             builder.withVotingPlugin().withTokenHolder(alice, 1 ether).build();

--- a/test/LockManagerERC20.t.yaml
+++ b/test/LockManagerERC20.t.yaml
@@ -49,6 +49,14 @@ LockManagerTest:
               - it: Should transfer the full allowance amount from the user
               - it: Should increase the user's lockedBalances by the allowance amount
               - it: Should emit a BalanceLocked event with the correct user and amount
+      - when: The user has approved the LockManager to spend more than the balance
+        comment: Allowance is ∞
+        and:
+          - when: Calling lock()
+            then:
+              - it: Should transfer the full balance from the user
+              - it: Should increase the user's lockedBalances by the balance
+              - it: Should emit a BalanceLocked event with the correct user and amount
 
   - given: pluginMode is Voting
     and:


### PR DESCRIPTION
Ensuring that lock() doesn't register more than the actual balance